### PR TITLE
Fix Error loading key: invalid format

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -66,7 +66,7 @@ echo "Registering SSH keys..."
 
 # register the private key with the agent.
 mkdir -p "$HOME/.ssh"
-printf '%s' "$INPUT_SSH_PRIVATE_KEY" > "$HOME/.ssh/id_rsa"
+printf '%s\n' "$INPUT_SSH_PRIVATE_KEY" > "$HOME/.ssh/id_rsa"
 chmod 600 "$HOME/.ssh/id_rsa"
 eval $(ssh-agent)
 ssh-add "$HOME/.ssh/id_rsa"


### PR DESCRIPTION
I've found a solution for #1 . As I see on my system, printf without trailing \n produces broken output. I believe it depends on [shell interpreter](https://superuser.com/questions/645599/why-is-a-percent-sign-appearing-before-each-prompt-on-zsh-in-windows/645612)

<img width="376" alt="image" src="https://user-images.githubusercontent.com/3585469/84786592-a5b25e80-aff5-11ea-87e4-2dd1a1d6f275.png">
