### PR TITLE
set docker-compose as INPUT_DEPLOYMENT_MODE if input not set

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -64,6 +64,7 @@ case $INPUT_DEPLOYMENT_MODE in
   ;;
 
   *)
+    INPUT_DEPLOYMENT_MODE="docker-compose"
     DEPLOYMENT_COMMAND="docker-compose $DEPLOYMENT_COMMAND_OPTIONS -f $STACK_FILE"
   ;;
 esac


### PR DESCRIPTION
If input deployment_mode is not set, pre_deployment_command_args and pull_images_first will be ignored.

Set INPUT_DEPLOYMENT_MODE to "docker-compose" if input deployment_mode is not set.