### PR TITLE
Fixed docker-compose pull command

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -102,7 +102,7 @@ if ! [ -z "$INPUT_COPY_STACK_FILE" ] && [ $INPUT_COPY_STACK_FILE = 'true' ] ; th
   execute_ssh "ls -t $INPUT_DEPLOY_PATH/stacks/docker-stack-* 2>/dev/null |  tail -n +$INPUT_KEEP_FILES | xargs rm --  2>/dev/null || true"
 
   if ! [ -z "$INPUT_PULL_IMAGES_FIRST" ] && [ $INPUT_PULL_IMAGES_FIRST = 'true' ] && [ $INPUT_DEPLOYMENT_MODE = 'docker-compose' ] ; then
-    execute_ssh "${DEPLOYMENT_COMMAND} pull"
+    execute_ssh ${DEPLOYMENT_COMMAND} "pull"
   fi
 
   if ! [ -z "$INPUT_PRE_DEPLOYMENT_COMMAND_ARGS" ] && [ $INPUT_DEPLOYMENT_MODE = 'docker-compose' ] ; then


### PR DESCRIPTION
The command wasn't working before. For some reason the shell didn't evaluate the `DEPLOYMENT_COMMAND` variable properly inside the string, so I moved it out of the string :)